### PR TITLE
Fixed typo for adGeneration method

### DIFF
--- a/src/NLPCloud.php
+++ b/src/NLPCloud.php
@@ -36,7 +36,7 @@ class NLPCloud
         $this->rootURL = $this->rootURL . $model;
     }
 
-    public function ad_generation($keywords)
+    public function adGeneration($keywords)
     {
         $payload = array(
             'keywords' => $keywords


### PR DESCRIPTION
Found another typo in adGeneration method name. Changed from ad_generation to adGeneration for consistency.